### PR TITLE
Feature/empty state component

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -12,7 +12,7 @@
   "plugins": ["prettier-plugin-tailwindcss"],
   "tailwindStylesheet": "./src/styles.css",
   "tailwindConfig": "./tailwind.config.ts",
-  "tailwindFunctions": ["clsx", "cn", "tw", "ngClass"],
+  "tailwindFunctions": ["class", "cn", "tw", "ngClass"],
   "tailwindPreserveWhitespace": true,
   "tailwindPreserveDuplicates": false
 }

--- a/src/shared/components/feedback/messages/empty-state/empty-state.component.html
+++ b/src/shared/components/feedback/messages/empty-state/empty-state.component.html
@@ -1,0 +1,24 @@
+<div
+  class="w-full rounded-8 p-2 bg-neutral-100 text-neutral-950 text-preset-5 border border-neutral-200 dark:bg-neutral-800 dark:text-white dark:border-neutral-700"
+>
+  @switch (variant()) {
+    @case ("all-notes") {
+      <p>
+        You don’t have any notes yet. Start a new note to capture your thoughts
+        and ideas.
+      </p>
+    }
+    @case ("archived") {
+      <p>
+        No notes have been archived yet. Move notes here for safekeeping, or
+        <a class="underline" routerLink="/notes/form">create a new note.</a>
+      </p>
+    }
+    @case ("search") {
+      <p>
+        No notes match your search. Try a different keyword or
+        <a class="underline" routerLink="/notes/form">create a new note.</a>
+      </p>
+    }
+  }
+</div>

--- a/src/shared/components/feedback/messages/empty-state/empty-state.component.ts
+++ b/src/shared/components/feedback/messages/empty-state/empty-state.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-empty-state',
+  imports: [RouterLink],
+  templateUrl: './empty-state.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class EmptyStateComponent {
+  variant = input.required<'search' | 'archived' | 'all-notes'>();
+}
+
+/**
+ * All your archived notes are stored here. You can restore or delete them anytime.
+ *
+ * All notes matching ”Dev” are displayed below.
+ *
+ * All notes matching ”Bananas” are displayed below.
+ */

--- a/src/shared/components/feedback/messages/empty-state/empty-state.component.ts
+++ b/src/shared/components/feedback/messages/empty-state/empty-state.component.ts
@@ -8,5 +8,5 @@ import { RouterLink } from '@angular/router';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EmptyStateComponent {
-  variant = input.required<'search' | 'archived' | 'all-notes'>();
+  readonly variant = input.required<'search' | 'archived' | 'all-notes'>();
 }

--- a/src/shared/components/feedback/messages/empty-state/empty-state.component.ts
+++ b/src/shared/components/feedback/messages/empty-state/empty-state.component.ts
@@ -10,11 +10,3 @@ import { RouterLink } from '@angular/router';
 export class EmptyStateComponent {
   variant = input.required<'search' | 'archived' | 'all-notes'>();
 }
-
-/**
- * All your archived notes are stored here. You can restore or delete them anytime.
- *
- * All notes matching ”Dev” are displayed below.
- *
- * All notes matching ”Bananas” are displayed below.
- */

--- a/src/shared/components/feedback/messages/message/message.component.html
+++ b/src/shared/components/feedback/messages/message/message.component.html
@@ -1,5 +1,5 @@
 <div class="text-preset-5 text-neutral-950 dark:text-white">
-  @if (variant() !== 'archived' && match()) {
+  @if (variant() !== "archived" && match()) {
     <p>All notes matching "{{ match() }}" are displayed below.</p>
   }
   @if (variant() === "archived" && !match()) {

--- a/src/shared/components/feedback/messages/message/message.component.html
+++ b/src/shared/components/feedback/messages/message/message.component.html
@@ -1,0 +1,11 @@
+<div class="text-preset-5 text-neutral-950 dark:text-white">
+  @if (variant() && match()) {
+    <p>All notes matching "{{ match() }}" are displayed below.</p>
+  }
+  @if (variant() === "archived" && !match()) {
+    <p>
+      All your archived notes are stored here. You can restore or delete them
+      anytime.
+    </p>
+  }
+</div>

--- a/src/shared/components/feedback/messages/message/message.component.html
+++ b/src/shared/components/feedback/messages/message/message.component.html
@@ -1,5 +1,5 @@
 <div class="text-preset-5 text-neutral-950 dark:text-white">
-  @if (variant() && match()) {
+  @if (variant() !== 'archived' && match()) {
     <p>All notes matching "{{ match() }}" are displayed below.</p>
   }
   @if (variant() === "archived" && !match()) {

--- a/src/shared/components/feedback/messages/message/message.component.ts
+++ b/src/shared/components/feedback/messages/message/message.component.ts
@@ -10,10 +10,3 @@ export class MessageComponent {
   readonly variant = input.required<'archived' | 'search' | 'tag'>();
   readonly match = input<string>('');
 }
-/**
- * All your archived notes are stored here. You can restore or delete them anytime.
- *
- * All notes matching ”Dev” are displayed below.
- *
- * All notes matching ”Bananas” are displayed below.
- */

--- a/src/shared/components/feedback/messages/message/message.component.ts
+++ b/src/shared/components/feedback/messages/message/message.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-message',
+  imports: [],
+  templateUrl: './message.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MessageComponent {
+  readonly variant = input.required<'archived' | 'search' | 'tag'>();
+  readonly match = input<string>('');
+}
+/**
+ * All your archived notes are stored here. You can restore or delete them anytime.
+ *
+ * All notes matching ”Dev” are displayed below.
+ *
+ * All notes matching ”Bananas” are displayed below.
+ */


### PR DESCRIPTION
This pull request introduces new components for displaying feedback messages and empty states in the notes application, along with a small configuration update for Tailwind CSS function detection. The main focus is on improving user experience by providing contextual messages when there are no notes or when searching/archiving notes.

**New feedback components:**

* Added `EmptyStateComponent` and its template (`empty-state.component.ts`, `empty-state.component.html`) to show contextual empty state messages for "all-notes", "archived", and "search" variants. [[1]](diffhunk://#diff-d6ae3fad55f8e39fc95b6d190a55f0721bccdd9d6032ffd12b0515f236d68256R1-R12) [[2]](diffhunk://#diff-e31c1c90e99a5579fd7e374100d95cd0241391a39e6118b8eb5568157673f180R1-R24)
* Added `MessageComponent` and its template (`message.component.ts`, `message.component.html`) to display feedback messages based on the current variant and search match. [[1]](diffhunk://#diff-6fdc6e1e981babe44b2c1215d6fea83a75b1192ba436430c841f860ccb28edebR1-R19) [[2]](diffhunk://#diff-3f5d57c6c28217d31e0d3d5c0e44192f50723e2733112c5d02186e66196bb9efR1-R11)

**Configuration update:**

* Updated the Tailwind CSS function detection in `.prettierrc`, replacing `"clsx"` with `"class"` in the `tailwindFunctions` array for improved compatibility.

Closes #34 