### PR TITLE
Feature/archived notes page

### DIFF
--- a/src/features/notes/components/sidebar/sidebar.component.html
+++ b/src/features/notes/components/sidebar/sidebar.component.html
@@ -6,5 +6,8 @@
     label="+ Create New Note"
     (clicked)="navigateToForm.set($event)"
   />
+  @if (notesRedirectionPath() !== "all") {
+    <app-message variant="archived" />
+  }
   <notes-list [notes]="notes()" [path]="notesRedirectionPath()" />
 </aside>

--- a/src/features/notes/components/sidebar/sidebar.component.ts
+++ b/src/features/notes/components/sidebar/sidebar.component.ts
@@ -6,13 +6,13 @@ import {
   signal,
 } from '@angular/core';
 import { NotesListComponent } from '../notes-list/notes-list.component';
-import { ButtonComponent } from '@shared/components';
+import { ButtonComponent, MessageComponent } from '@shared/components';
 import { Note } from '@features/notes/interfaces/Note.interface';
 import { Router } from '@angular/router';
 
 @Component({
   selector: 'notes-sidebar',
-  imports: [NotesListComponent, ButtonComponent],
+  imports: [NotesListComponent, ButtonComponent, MessageComponent],
   templateUrl: './sidebar.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/features/notes/notes.routes.ts
+++ b/src/features/notes/notes.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import TemporalComponentComponent from './components/temporal-component/temporal-component.component';
 import { NotesLayoutComponent } from '@shared/layouts/notes-layout/notes-layout.component';
 import AllNotesPageComponent from './pages/all-notes-page/all-notes-page.component';
+import ArchivedNotesPageComponent from './pages/archived-notes-page/archived-notes-page.component';
 
 const notesRouter: Routes = [
   {
@@ -18,7 +19,11 @@ const notesRouter: Routes = [
       },
       {
         path: 'archived',
-        loadComponent: () => TemporalComponentComponent,
+        loadComponent: () => ArchivedNotesPageComponent,
+      },
+      {
+        path: 'archived/:id',
+        loadComponent: () => ArchivedNotesPageComponent,
       },
       {
         path: 'details/:id',

--- a/src/features/notes/pages/archived-notes-page/archived-notes-page.component.html
+++ b/src/features/notes/pages/archived-notes-page/archived-notes-page.component.html
@@ -1,0 +1,19 @@
+<div class="flex flex-1 h-full min-h-0">
+  <notes-sidebar [notes]="notes" notesRedirectionPath="archived" />
+  <section
+    class="h-full bg-white flex-1 overflow-y-auto rounded-t-12 lg:rounded-t-0 lg:w-[588px] xl:w-[40%] dark:bg-neutral-950 flex flex-col min-h-0"
+  >
+    <div
+      class="min-h-full flex flex-col gap-y-4 py-5 px-4 md:py-6 md:px-8 lg:hidden flex-shrink-0"
+      [class.hidden]="getRouteParams()"
+    >
+      <app-title title="Archived Notes" />
+      <app-message variant="archived" />
+      <notes-list [notes]="notes" class="lg:hidden" path="all" />
+    </div>
+    <div class="flex-1 w-full min-h-0">
+      <notes-note-details [headerControlOptions]="menuControlOptions" />
+    </div>
+  </section>
+  <notes-right-menu [optionsToDisplay]="menuControlOptions" />
+</div>

--- a/src/features/notes/pages/archived-notes-page/archived-notes-page.component.html
+++ b/src/features/notes/pages/archived-notes-page/archived-notes-page.component.html
@@ -9,7 +9,7 @@
     >
       <app-title title="Archived Notes" />
       <app-message variant="archived" />
-      <notes-list [notes]="notes" class="lg:hidden" path="all" />
+      <notes-list [notes]="notes" class="lg:hidden" path="archived" />
     </div>
     <div class="flex-1 w-full min-h-0">
       <notes-note-details [headerControlOptions]="menuControlOptions" />

--- a/src/features/notes/pages/archived-notes-page/archived-notes-page.component.ts
+++ b/src/features/notes/pages/archived-notes-page/archived-notes-page.component.ts
@@ -1,0 +1,75 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { SidebarComponent } from '@features/notes/components/sidebar/sidebar.component';
+import { SectionTitleComponent, MessageComponent } from '@shared/components';
+import { RightMenuComponent } from '@features/notes/components/right-menu/right-menu.component';
+import { NoteDetailsComponent } from '@features/notes/components/note-details/note-details.component';
+import { NotesListComponent } from '@features/notes/components/notes-list/notes-list.component';
+import { ActivatedRoute } from '@angular/router';
+import { Note } from '@features/notes/interfaces/Note.interface';
+import { RightMenuOptions } from '@shared/interfaces';
+
+@Component({
+  selector: 'notes-archived-notes-page',
+  imports: [
+    SidebarComponent,
+    SectionTitleComponent,
+    RightMenuComponent,
+    NoteDetailsComponent,
+    NotesListComponent,
+    MessageComponent,
+  ],
+  templateUrl: './archived-notes-page.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class ArchivedNotesPageComponent {
+  private readonly activeRoute = inject(ActivatedRoute);
+
+  protected menuControlOptions: RightMenuOptions[] = ['delete', 'restore'];
+  protected readonly notes: Note[] = [
+    {
+      id: '1',
+      title: 'eej',
+      tags: ['s', 'm'],
+      updatedAt: new Date('2024-06-01T12:00:00Z'),
+      content: 'Sample note content',
+      archived: false,
+    },
+    {
+      id: '2',
+      title: 'Angular Signals',
+      tags: ['angular', 'signals'],
+      updatedAt: new Date('2024-06-02T09:30:00Z'),
+      content: 'Exploring the new signals API in Angular 20.',
+      archived: false,
+    },
+    {
+      id: '3',
+      title: 'Archived Note',
+      tags: ['archive'],
+      updatedAt: new Date('2024-05-28T15:45:00Z'),
+      content: 'This note is archived.',
+      archived: true,
+    },
+    {
+      id: '4',
+      title: 'Archived Note',
+      tags: ['archive'],
+      updatedAt: new Date('2024-05-28T15:45:00Z'),
+      content: 'This note is archived.',
+      archived: true,
+    },
+    {
+      id: '5',
+      title: 'Archived Note',
+      tags: ['archive'],
+      updatedAt: new Date('2024-05-28T15:45:00Z'),
+      content: 'This note is archived.',
+      archived: true,
+    },
+  ];
+
+  protected getRouteParams() {
+    return this.activeRoute.snapshot.paramMap.get('id') ?? undefined;
+  }
+}
+export default ArchivedNotesPageComponent;

--- a/src/shared/components/feedback/messages/message/message.component.ts
+++ b/src/shared/components/feedback/messages/message/message.component.ts
@@ -7,6 +7,6 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MessageComponent {
-  readonly variant = input.required<'archived' | 'search' | 'tag'>();
+  readonly variant = input.required<'archived' | 'search' | 'tags'>();
   readonly match = input<string>('');
 }


### PR DESCRIPTION
This pull request introduces the "Archived Notes" feature to the notes module, enabling users to view and interact with archived notes. The main changes include new routing for archived notes, a dedicated page and component for displaying archived notes, and UI updates to support this functionality.

### Archived Notes Feature

* Added `ArchivedNotesPageComponent` to display archived notes, including its template and logic for rendering notes, sidebar, and details. [[1]](diffhunk://#diff-328322c8ee040e0e2e9aaf2d41d919244dca0938d832600ee473e2456dec3de7R1-R75) [[2]](diffhunk://#diff-dfa72f316bc3b66e74d84ea47e4ff900165a11cd6382005b313bc17d4e07b52eR1-R19)
* Updated routing in `notes.routes.ts` to support `/archived` and `/archived/:id` paths, loading the new archived notes page component. [[1]](diffhunk://#diff-517ef8c40eeda4a0aa9d062ecca35ab7a890950d2421eef25da4408e30c31ed9R5) [[2]](diffhunk://#diff-517ef8c40eeda4a0aa9d062ecca35ab7a890950d2421eef25da4408e30c31ed9L21-R26)

### UI Updates

* Modified `sidebar.component.html` to show an archived message when viewing archived notes.
* Updated sidebar component imports to include `MessageComponent` for displaying status messages.

### Minor Fixes

* Fixed the `variant` input type in `MessageComponent` to support `'tags'` instead of `'tag'`.

Closes #44 