### PR TITLE
Feature/tagged notes page

### DIFF
--- a/src/core/services/title.service.ts
+++ b/src/core/services/title.service.ts
@@ -1,0 +1,76 @@
+import { computed, inject, Injectable } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { filter, map, startWith } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TitleService {
+  private readonly _router = inject(Router);
+  private readonly _activatedRoute = inject(ActivatedRoute);
+
+  private readonly _currentRoute = toSignal(
+    this._router.events.pipe(
+      filter((event) => event instanceof NavigationEnd),
+      startWith(new NavigationEnd(0, '', '')),
+      map(() => this._getDeepestRoute()),
+    ),
+    { initialValue: this._getDeepestRoute() },
+  );
+
+  private readonly _baseTitle = computed(() => {
+    const route = this._currentRoute();
+    return (
+      route.snapshot.title || route.snapshot.data?.['title'] || 'All Notes'
+    );
+  });
+
+  private readonly _routeParams = computed(() => {
+    const route = this._currentRoute();
+    return route.snapshot.paramMap;
+  });
+
+  readonly title = computed(() => {
+    const baseTitle = this._baseTitle();
+    const paramMap = this._routeParams();
+
+    switch (baseTitle) {
+      case 'Notes tagged':
+        return paramMap.get('tag') ? 'Notes Tagged' : baseTitle;
+      case 'Showing results for':
+        return paramMap.get('query') ? 'Showing results for' : 'Search Results';
+      default:
+        return baseTitle;
+    }
+  });
+
+  readonly match = computed(() => {
+    const baseTitle = this._baseTitle();
+    const paramMap = this._routeParams();
+
+    switch (baseTitle) {
+      case 'Notes tagged':
+        return paramMap.get('tag') || undefined;
+      case 'Showing results for':
+        return paramMap.get('query') || undefined;
+      default:
+        return undefined;
+    }
+  });
+
+  getValues(): { title: string; match?: string } {
+    return {
+      title: this.title(),
+      match: this.match(),
+    };
+  }
+
+  private _getDeepestRoute(): ActivatedRoute {
+    let route = this._activatedRoute;
+    while (route.firstChild) {
+      route = route.firstChild;
+    }
+    return route;
+  }
+}

--- a/src/features/notes/components/notes-list/note-item/note-item.component.ts
+++ b/src/features/notes/components/notes-list/note-item/note-item.component.ts
@@ -22,7 +22,9 @@ export class NoteItemComponent implements OnInit {
   private readonly activeRoute = inject(ActivatedRoute);
 
   readonly note = input.required<Note>();
-  readonly path = input.required<'all' | 'archived' | 'tags' | 'search'>();
+  readonly path = input.required<
+    'all' | 'archived' | 'tags' | 'search' | `/tags/${string}`
+  >();
   protected readonly selectedNote = signal<string | null>(null);
   protected readonly isSelected = computed(() => {
     if (!this.selectedNote()) return false;

--- a/src/features/notes/components/notes-list/notes-list.component.ts
+++ b/src/features/notes/components/notes-list/notes-list.component.ts
@@ -10,5 +10,7 @@ import { NoteItemComponent } from './note-item/note-item.component';
 })
 export class NotesListComponent {
   readonly notes = input<Note[]>([]);
-  readonly path = input.required<'all' | 'archived' | 'tags' | 'search'>();
+  readonly path = input.required<
+    'all' | 'archived' | 'tags' | 'search' | `/tags/${string}`
+  >();
 }

--- a/src/features/notes/components/sidebar/sidebar.component.ts
+++ b/src/features/notes/components/sidebar/sidebar.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   inject,
   input,
   signal,
@@ -9,6 +10,7 @@ import { NotesListComponent } from '../notes-list/notes-list.component';
 import { ButtonComponent, MessageComponent } from '@shared/components';
 import { Note } from '@features/notes/interfaces/Note.interface';
 import { Router } from '@angular/router';
+import { TitleService } from '@core/services/title.service';
 
 @Component({
   selector: 'notes-sidebar',
@@ -18,6 +20,8 @@ import { Router } from '@angular/router';
 })
 export class SidebarComponent {
   private readonly router = inject(Router);
+  private readonly titleService = inject(TitleService);
+
   readonly notes = input<Note[]>([]);
   readonly notesRedirectionPath = input.required<
     'all' | 'archived' | 'tags' | 'search' | `/tags/${string}`
@@ -30,4 +34,8 @@ export class SidebarComponent {
       this.navigateToForm.set(false);
     }
   };
+
+  protected readonly matchValue = computed(
+    () => this.titleService.getValues().match,
+  );
 }

--- a/src/features/notes/components/sidebar/sidebar.component.ts
+++ b/src/features/notes/components/sidebar/sidebar.component.ts
@@ -20,7 +20,7 @@ export class SidebarComponent {
   private readonly router = inject(Router);
   readonly notes = input<Note[]>([]);
   readonly notesRedirectionPath = input.required<
-    'all' | 'archived' | 'tags' | 'search'
+    'all' | 'archived' | 'tags' | 'search' | `/tags/${string}`
   >();
   readonly navigateToForm = signal<boolean>(false);
 

--- a/src/features/notes/components/tags-list/tag-item/tag-item.component.html
+++ b/src/features/notes/components/tags-list/tag-item/tag-item.component.html
@@ -1,5 +1,5 @@
 <div
-  class="flex gap-x-2 px-3 py-2.5 items-center hover:cursor-pointer rounded-8"
+  class="flex gap-x-2 lg:px-3 py-2.5 items-center hover:cursor-pointer rounded-8"
   tabindex="0"
   (click)="handleTagClick()"
   (keyup.enter)="handleTagClick()"

--- a/src/features/notes/components/tags-list/tags-list.component.html
+++ b/src/features/notes/components/tags-list/tags-list.component.html
@@ -1,5 +1,10 @@
 <div class="flex flex-col gap-y-1 w-full h-fit lg:max-h-80 overflow-y-auto">
-  @for (tag of tags(); track $index) {
-    <notes-tag-item [tag]="tag" />
+  @for (tag of tags(); track $index; let isLast = $last) {
+    <div class="flex flex-col gap-y-1">
+      <notes-tag-item [tag]="tag" />
+      @if (!isLast) {
+        <span class="border-b dark:border-b-neutral-800 lg:border-0"></span>
+      }
+    </div>
   }
 </div>

--- a/src/features/notes/notes.routes.ts
+++ b/src/features/notes/notes.routes.ts
@@ -3,6 +3,8 @@ import TemporalComponentComponent from './components/temporal-component/temporal
 import { NotesLayoutComponent } from '@shared/layouts/notes-layout/notes-layout.component';
 import AllNotesPageComponent from './pages/all-notes-page/all-notes-page.component';
 import ArchivedNotesPageComponent from './pages/archived-notes-page/archived-notes-page.component';
+import TaggedNotesPageComponent from './pages/tagged-notes-page/tagged-notes-page.component';
+import TagsPageComponent from './pages/tags-page/tags-page.component';
 
 const notesRouter: Routes = [
   {
@@ -39,11 +41,15 @@ const notesRouter: Routes = [
       },
       {
         path: 'tags',
-        loadComponent: () => TemporalComponentComponent,
+        loadComponent: () => TagsPageComponent,
       },
       {
         path: 'tags/:tag',
-        loadComponent: () => TemporalComponentComponent,
+        loadComponent: () => TaggedNotesPageComponent,
+      },
+      {
+        path: 'tags/:tag/:id',
+        loadComponent: () => TaggedNotesPageComponent,
       },
     ],
   },

--- a/src/features/notes/notes.routes.ts
+++ b/src/features/notes/notes.routes.ts
@@ -14,18 +14,22 @@ const notesRouter: Routes = [
       {
         path: 'all',
         loadComponent: () => AllNotesPageComponent,
+        title: 'All Notes',
       },
       {
         path: 'all/:id',
         loadComponent: () => AllNotesPageComponent,
+        title: 'All Notes',
       },
       {
         path: 'archived',
         loadComponent: () => ArchivedNotesPageComponent,
+        title: 'Archived',
       },
       {
         path: 'archived/:id',
         loadComponent: () => ArchivedNotesPageComponent,
+        title: 'Archived',
       },
       {
         path: 'details/:id',
@@ -34,22 +38,27 @@ const notesRouter: Routes = [
       {
         path: 'form',
         loadComponent: () => TemporalComponentComponent,
+        title: 'All Notes',
       },
       {
         path: 'search',
         loadComponent: () => TemporalComponentComponent,
+        title: 'Showing results for',
       },
       {
         path: 'tags',
         loadComponent: () => TagsPageComponent,
+        title: 'Tags',
       },
       {
         path: 'tags/:tag',
         loadComponent: () => TaggedNotesPageComponent,
+        title: 'Notes tagged',
       },
       {
         path: 'tags/:tag/:id',
         loadComponent: () => TaggedNotesPageComponent,
+        title: 'Notes tagged',
       },
     ],
   },

--- a/src/features/notes/pages/tagged-notes-page/tagged-notes-page.component.html
+++ b/src/features/notes/pages/tagged-notes-page/tagged-notes-page.component.html
@@ -1,0 +1,18 @@
+<div class="flex flex-1 h-full min-h-0 overflow-y-auto">
+  <notes-sidebar [notes]="notes" [notesRedirectionPath]="getRoute()" />
+  <section
+    class="h-full bg-white flex-1 overflow-y-auto rounded-t-12 lg:rounded-t-0 lg:w-[588px] xl:w-[40%] dark:bg-neutral-950 flex flex-col min-h-0"
+  >
+    <div
+      class="min-h-full flex flex-col gap-y-4 py-5 px-4 md:py-6 md:px-8 lg:hidden flex-shrink-0"
+      [class.hidden]="getNoteIdRouteParams()"
+    >
+      <app-title title="Notes Tagged" [match]="getTagRouteParam()" />
+      <notes-list [notes]="notes" class="lg:hidden" [path]="getRoute()" />
+    </div>
+    <div class="flex-1 w-full min-h-0">
+      <notes-note-details [headerControlOptions]="menuControlOptions" />
+    </div>
+  </section>
+  <notes-right-menu [optionsToDisplay]="menuControlOptions" />
+</div>

--- a/src/features/notes/pages/tagged-notes-page/tagged-notes-page.component.html
+++ b/src/features/notes/pages/tagged-notes-page/tagged-notes-page.component.html
@@ -1,14 +1,14 @@
 <div class="flex flex-1 h-full min-h-0 overflow-y-auto">
-  <notes-sidebar [notes]="notes" [notesRedirectionPath]="getRoute()" />
+  <notes-sidebar [notes]="notes" [notesRedirectionPath]="route()" />
   <section
     class="h-full bg-white flex-1 overflow-y-auto rounded-t-12 lg:rounded-t-0 lg:w-[588px] xl:w-[40%] dark:bg-neutral-950 flex flex-col min-h-0"
   >
     <div
       class="min-h-full flex flex-col gap-y-4 py-5 px-4 md:py-6 md:px-8 lg:hidden flex-shrink-0"
-      [class.hidden]="getNoteIdRouteParams()"
+      [class.hidden]="noteIdRouteParam()"
     >
-      <app-title title="Notes Tagged" [match]="getTagRouteParam()" />
-      <notes-list [notes]="notes" class="lg:hidden" [path]="getRoute()" />
+      <app-title title="Notes Tagged" [match]="tagRouteParam()" />
+      <notes-list [notes]="notes" class="lg:hidden" [path]="route()" />
     </div>
     <div class="flex-1 w-full min-h-0">
       <notes-note-details [headerControlOptions]="menuControlOptions" />

--- a/src/features/notes/pages/tagged-notes-page/tagged-notes-page.component.ts
+++ b/src/features/notes/pages/tagged-notes-page/tagged-notes-page.component.ts
@@ -1,0 +1,82 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { SidebarComponent } from '@features/notes/components/sidebar/sidebar.component';
+import { SectionTitleComponent } from '@shared/components';
+import { NotesListComponent } from '@features/notes/components/notes-list/notes-list.component';
+import { NoteDetailsComponent } from '@features/notes/components/note-details/note-details.component';
+import { RightMenuComponent } from '@features/notes/components/right-menu/right-menu.component';
+import { Note } from '@features/notes/interfaces/Note.interface';
+import { RightMenuOptions } from '@shared/interfaces';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'notes-tagged-notes-page',
+  imports: [
+    SidebarComponent,
+    SectionTitleComponent,
+    NotesListComponent,
+    NoteDetailsComponent,
+    RightMenuComponent,
+  ],
+  templateUrl: './tagged-notes-page.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TaggedNotesPageComponent {
+  private readonly activeRoute = inject(ActivatedRoute);
+
+  protected menuControlOptions: RightMenuOptions[] = ['delete', 'archive'];
+  protected readonly notes: Note[] = [
+    {
+      id: '1',
+      title: 'eej',
+      tags: ['s', 'm'],
+      updatedAt: new Date('2024-06-01T12:00:00Z'),
+      content: 'Sample note content',
+      archived: false,
+    },
+    {
+      id: '2',
+      title: 'Angular Signals',
+      tags: ['angular', 'signals'],
+      updatedAt: new Date('2024-06-02T09:30:00Z'),
+      content: 'Exploring the new signals API in Angular 20.',
+      archived: false,
+    },
+    {
+      id: '3',
+      title: 'Archived Note',
+      tags: ['archive'],
+      updatedAt: new Date('2024-05-28T15:45:00Z'),
+      content: 'This note is archived.',
+      archived: true,
+    },
+    {
+      id: '4',
+      title: 'Archived Note',
+      tags: ['archive'],
+      updatedAt: new Date('2024-05-28T15:45:00Z'),
+      content: 'This note is archived.',
+      archived: true,
+    },
+    {
+      id: '5',
+      title: 'Archived Note',
+      tags: ['archive'],
+      updatedAt: new Date('2024-05-28T15:45:00Z'),
+      content: 'This note is archived.',
+      archived: true,
+    },
+  ];
+
+  protected getTagRouteParam() {
+    return this.activeRoute.snapshot.paramMap.get('tag') ?? undefined;
+  }
+
+  protected getNoteIdRouteParams() {
+    return this.activeRoute.snapshot.paramMap.get('id') ?? undefined;
+  }
+
+  protected getRoute() {
+    return `/tags/${this.getTagRouteParam()}` as `/tags/${string}`;
+  }
+}
+export default TaggedNotesPageComponent;

--- a/src/features/notes/pages/tagged-notes-page/tagged-notes-page.component.ts
+++ b/src/features/notes/pages/tagged-notes-page/tagged-notes-page.component.ts
@@ -1,4 +1,9 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+} from '@angular/core';
 import { SidebarComponent } from '@features/notes/components/sidebar/sidebar.component';
 import { SectionTitleComponent } from '@shared/components';
 import { NotesListComponent } from '@features/notes/components/notes-list/notes-list.component';
@@ -67,16 +72,14 @@ class TaggedNotesPageComponent {
     },
   ];
 
-  protected getTagRouteParam() {
-    return this.activeRoute.snapshot.paramMap.get('tag') ?? undefined;
-  }
-
-  protected getNoteIdRouteParams() {
-    return this.activeRoute.snapshot.paramMap.get('id') ?? undefined;
-  }
-
-  protected getRoute() {
-    return `/tags/${this.getTagRouteParam()}` as `/tags/${string}`;
-  }
+  protected readonly tagRouteParam = computed(
+    () => this.activeRoute.snapshot.paramMap.get('tag') ?? undefined,
+  );
+  protected readonly noteIdRouteParam = computed(
+    () => this.activeRoute.snapshot.paramMap.get('id') ?? undefined,
+  );
+  protected readonly route = computed(
+    () => `/tags/${this.tagRouteParam()}` as `/tags/${string}`,
+  );
 }
 export default TaggedNotesPageComponent;

--- a/src/features/notes/pages/tags-page/tags-page.component.html
+++ b/src/features/notes/pages/tags-page/tags-page.component.html
@@ -1,0 +1,8 @@
+<div
+  class="flex flex-col gap-y-4 flex-1 py-6 px-8 h-full min-h-0 overflow-y-auto bg-white rounded-t-12 lg:rounded-t-0 lg:hidden dark:bg-neutral-950"
+>
+  <app-title title="Tags" />
+  <notes-tags-list
+    [tags]="['work', 'personal', 'fun', 'research', 'projects']"
+  />
+</div>

--- a/src/features/notes/pages/tags-page/tags-page.component.ts
+++ b/src/features/notes/pages/tags-page/tags-page.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { TagsListComponent } from '@features/notes/components/tags-list/tags-list.component';
+import { SectionTitleComponent } from '@shared/components';
+
+@Component({
+  selector: 'notes-tags-page',
+  imports: [TagsListComponent, SectionTitleComponent],
+  templateUrl: './tags-page.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TagsPageComponent {}
+export default TagsPageComponent;

--- a/src/shared/components/feedback/messages/message/message.component.ts
+++ b/src/shared/components/feedback/messages/message/message.component.ts
@@ -8,5 +8,5 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 })
 export class MessageComponent {
   readonly variant = input.required<'archived' | 'search' | 'tags'>();
-  readonly match = input<string>('');
+  readonly match = input<string | undefined>(undefined);
 }

--- a/src/shared/components/layout/header/header.component.html
+++ b/src/shared/components/layout/header/header.component.html
@@ -2,7 +2,7 @@
   <div
     class="hidden lg:flex items-center w-full h-[81px] px-8 flex-1 lg:border-solid border-b border-neutral-200 dark:border-neutral-200/30 justify-between"
   >
-    <app-title title="Section" />
+    <app-title [title]="titleValues().title" [match]="titleValues().match" />
     <div class="flex gap-4 items-center justify-center">
       <app-input
         class="w-[300px]"

--- a/src/shared/components/layout/header/header.component.ts
+++ b/src/shared/components/layout/header/header.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   computed,
   inject,
-  effect,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TitleService } from '@core/services/title.service';
@@ -31,9 +30,5 @@ export class HeaderComponent {
 
   protected readonly titleValues = computed(() => {
     return this.titleService.getValues();
-  });
-
-  private readonly values = effect(() => {
-    console.log(this.titleService.getValues());
   });
 }

--- a/src/shared/components/layout/header/header.component.ts
+++ b/src/shared/components/layout/header/header.component.ts
@@ -1,5 +1,12 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  effect,
+} from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { TitleService } from '@core/services/title.service';
 import {
   InputComponent,
   LogoComponent,
@@ -19,4 +26,14 @@ import { IconSettingsComponent } from '@shared/components/ui/icons';
   templateUrl: './header.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class HeaderComponent {}
+export class HeaderComponent {
+  titleService = inject(TitleService);
+
+  protected readonly titleValues = computed(() => {
+    return this.titleService.getValues();
+  });
+
+  private readonly values = effect(() => {
+    console.log(this.titleService.getValues());
+  });
+}

--- a/src/shared/components/layout/sidebar/sidebar.component.html
+++ b/src/shared/components/layout/sidebar/sidebar.component.html
@@ -5,7 +5,7 @@
   <app-nav />
   <span class="border-t border-neutral-200 dark:border-neutral-200/20"></span>
   <div>
-    <p class="text-preset-4 text-neutral-500 mb-2 px-4">Tags</p>
+    <p class="text-preset-4 text-neutral-500 mb-2 px-3">Tags</p>
     <notes-tags-list
       [tags]="['work', 'personal', 'urgent', 'idea', 'todo', 'review']"
     />

--- a/src/shared/components/ui/title/title.component.html
+++ b/src/shared/components/ui/title/title.component.html
@@ -1,1 +1,12 @@
-<h1 class="text-preset-1 text-neutral-950 dark:text-white">{{ title() }}</h1>
+@if (match()) {
+  <h1 class="text-preset-1 text-neutral-600 dark:text-neutral-400">
+    {{ title() | titlecase }}:
+    <span class="text-neutral-950 dark:text-white">{{
+      match() | titlecase
+    }}</span>
+  </h1>
+} @else {
+  <h1 class="text-preset-1 text-neutral-950 dark:text-white">
+    {{ title() | titlecase }}
+  </h1>
+}

--- a/src/shared/components/ui/title/title.component.ts
+++ b/src/shared/components/ui/title/title.component.ts
@@ -1,5 +1,12 @@
 import { TitleCasePipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  input,
+} from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { TitleService } from '@core/services/title.service';
 
 @Component({
   selector: 'app-title',
@@ -8,6 +15,9 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SectionTitleComponent {
+  private readonly activeRoute = inject(ActivatedRoute);
+  private readonly titleService = inject(TitleService);
+
   title = input.required<string>();
   match = input<string | undefined>(undefined);
 }

--- a/src/shared/components/ui/title/title.component.ts
+++ b/src/shared/components/ui/title/title.component.ts
@@ -1,11 +1,13 @@
+import { TitleCasePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 @Component({
   selector: 'app-title',
-  imports: [],
+  imports: [TitleCasePipe],
   templateUrl: './title.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SectionTitleComponent {
   title = input.required<string>();
+  match = input<string | undefined>(undefined);
 }


### PR DESCRIPTION
This pull request introduces significant improvements to how titles and navigation are handled in the notes feature, especially for tag-based and search-based routes. It adds new pages for viewing notes by tag, refactors the title system to be dynamic and context-aware, and updates routing and component props to support these changes. The sidebar and tags list UI are also enhanced for better clarity.

### Title and Navigation System Improvements

* Added a new `TitleService` (`src/core/services/title.service.ts`) to dynamically compute page titles and matched parameters based on the current route, supporting context-aware headers for tags and search results.
* Refactored the header and title components (`header.component.ts`, `title.component.ts`, `title.component.html`) to use the new title service, displaying context-specific titles and matched parameters (e.g., tag names or search queries) in the UI. [[1]](diffhunk://#diff-ca06271d04c35051cf56fa248f743030d154576bf4afe4322ca33e7523209943L22-R39) [[2]](diffhunk://#diff-f1e5a05c19a3e5ee1faff6bf05156d316a27da8c6e286a60bc9a71451b0ac303L1-R12) [[3]](diffhunk://#diff-f36f1e610d814b491088178516f209aab160f7c00ffc8ca6135dc14abb1b09b8L1-R22) [[4]](diffhunk://#diff-7300a22b611201efb97eb8f8189a0b155bcd76161b0bab7d5eb7ffc51ae0198fL5-R5)

### Routing and Page Additions

* Updated the notes routing (`notes.routes.ts`) to add dedicated pages for tags (`TagsPageComponent`) and tagged notes (`TaggedNotesPageComponent`), with appropriate titles set for each route, including support for nested routes like `/tags/:tag/:id`. [[1]](diffhunk://#diff-517ef8c40eeda4a0aa9d062ecca35ab7a890950d2421eef25da4408e30c31ed9R17-R32) [[2]](diffhunk://#diff-517ef8c40eeda4a0aa9d062ecca35ab7a890950d2421eef25da4408e30c31ed9R41-R61) [[3]](diffhunk://#diff-517ef8c40eeda4a0aa9d062ecca35ab7a890950d2421eef25da4408e30c31ed9R6-R7)
* Implemented new components for the tags page (`tags-page.component.ts`, `tags-page.component.html`) and tagged notes page (`tagged-notes-page.component.ts`, `tagged-notes-page.component.html`), displaying relevant notes and tag information. [[1]](diffhunk://#diff-e97ef83d61f53f890acb7c9a13fe847563942279e967b9fb65624f30e2358e88R1-R12) [[2]](diffhunk://#diff-ee0755b86aa87847451a7d17d30086226cf8e7d59db5cd0eb69f942bd8bce4a5R1-R8) [[3]](diffhunk://#diff-b7c9a4a8d178f45ffa6025a750bf3caaea2530afdc82f78f6b8073c81009893bR1-R82) [[4]](diffhunk://#diff-117b53b04d5624d2910bec6de016251339f9eca5f31bc4a00861e033f26b7826R1-R18)

### Component Prop and UI Updates

* Extended the `path` prop in notes-related components (`note-item.component.ts`, `notes-list.component.ts`, `sidebar.component.ts`) to support dynamic tag-based paths (e.g., `/tags/${string}`), enabling proper rendering and navigation for tagged notes. [[1]](diffhunk://#diff-bc4f3787b79841d1335281bb8fe40ff2de423f91c2ad358a3e4a522093b72e29L25-R27) [[2]](diffhunk://#diff-991bd279f0f9f9145c7b4017615d51238e20af6b1e7446015416f03df6d13a57L13-R15) [[3]](diffhunk://#diff-55de7a851556403e1b06aeef33e62625c5228f8eb2f00989485a8ddc28754b1cL23-R23)
* Improved the tags list UI to visually separate tag items with borders and adjusted padding for consistency. [[1]](diffhunk://#diff-a7fbca63e38a8b8d9c5db93b80390f5c9bec5199257e72b8a34f6af381abf377L2-R8) [[2]](diffhunk://#diff-a91e53575a5ff16d45bac79d4a81795c79fe4bcdcc084e4fc8fc0638438f9621L2-R2) [[3]](diffhunk://#diff-425de9f547b74e49c0256f8fb36a974b74af1555bc545c1ecfddbd755ff1bdd7L8-R8)

These changes collectively make the notes feature more robust, user-friendly, and maintainable, especially when handling tags and search functionality.

Closes #46 #52 