### PR TITLE
feat(auth): add signup page and update routing; modify login page link

### DIFF
--- a/src/features/auth/auth.routes.ts
+++ b/src/features/auth/auth.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import TemporalComponentComponent from '@features/notes/components/temporal-component/temporal-component.component';
 import { AuthLayoutComponent } from '@shared/layouts/auth-layout/auth-layout.component';
 import LoginPageComponent from './pages/login-page/login-page.component';
+import SignupPageComponent from './pages/signup-page/signup-page.component';
 
 const authRoutes: Routes = [
   {
@@ -14,7 +15,7 @@ const authRoutes: Routes = [
       },
       {
         path: 'signup',
-        loadComponent: () => TemporalComponentComponent,
+        loadComponent: () => SignupPageComponent,
       },
       {
         path: 'forgot-password',

--- a/src/features/auth/pages/login-page/login-page.component.html
+++ b/src/features/auth/pages/login-page/login-page.component.html
@@ -41,7 +41,7 @@
         No account yet?
         <a
           routerLink="/auth/signup"
-          class="dark:text-white hover:text-blue-500 hover:cursor-pointe"
+          class="dark:text-white hover:text-blue-500 hover:cursor-pointer"
           >Sign Up</a
         >
       </div>

--- a/src/features/auth/pages/login-page/login-page.component.ts
+++ b/src/features/auth/pages/login-page/login-page.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@shared/components';
 
 @Component({
-  selector: 'app-login-page',
+  selector: 'auth-login-page',
   imports: [
     LogoComponent,
     SectionTitleComponent,

--- a/src/features/auth/pages/signup-page/signup-page.component.html
+++ b/src/features/auth/pages/signup-page/signup-page.component.html
@@ -7,9 +7,9 @@
     >
       <app-logo />
       <div>
-        <app-title title="Welcome to Note" />
+        <app-title title="Create Your Account" />
         <p class="text-preset-5 text-neutral-600 dark:text-neutral-300 mt-2">
-          Please log in to continue
+          Sign up to start organizing your notes and boost your productivity.
         </p>
       </div>
     </header>
@@ -25,8 +25,7 @@
         placeholder="Enter your password"
         iconName="show"
         iconPlacement="end"
-        redirectionPath="/auth/forgot-password"
-        redirectionLabel="Forgot"
+        hintMessage="At least 8 characters"
       />
       <app-button variant="primary" label="Login" />
     </form>
@@ -38,11 +37,11 @@
       <div
         class="border-t border-solid border-neutral-200 dark:border-neutral-800 pt-4"
       >
-        No account yet?
+        Already have an account?
         <a
-          routerLink="/auth/signup"
-          class="dark:text-white hover:text-blue-500 hover:cursor-pointe"
-          >Sign Up</a
+          routerLink="/auth/login"
+          class="dark:text-white hover:text-blue-500 hover:cursor-pointer"
+          >Login</a
         >
       </div>
     </footer>

--- a/src/features/auth/pages/signup-page/signup-page.component.html
+++ b/src/features/auth/pages/signup-page/signup-page.component.html
@@ -27,7 +27,7 @@
         iconPlacement="end"
         hintMessage="At least 8 characters"
       />
-      <app-button variant="primary" label="Login" />
+      <app-button variant="primary" label="Sign Up" />
     </form>
     <footer
       class="border-t border-solid border-neutral-200 dark:border-neutral-800 pt-6 text-preset-5 dark:text-neutral-300 flex flex-col gap-y-4 justify-center text-center"

--- a/src/features/auth/pages/signup-page/signup-page.component.ts
+++ b/src/features/auth/pages/signup-page/signup-page.component.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  ButtonComponent,
+  InputComponent,
+  SectionTitleComponent,
+  LogoComponent,
+  IconGoogleComponent,
+} from '@shared/components';
+
+@Component({
+  selector: 'auth-signup-page',
+  imports: [
+    ButtonComponent,
+    InputComponent,
+    SectionTitleComponent,
+    LogoComponent,
+  ],
+  templateUrl: './signup-page.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export default class SignupPageComponent {
+  protected readonly GoogleIcon = IconGoogleComponent;
+}

--- a/src/shared/components/ui/input/input.component.ts
+++ b/src/shared/components/ui/input/input.component.ts
@@ -37,7 +37,7 @@ export class InputComponent {
   readonly iconName = input<'show' | 'search'>();
   readonly iconPlacement = input<'start' | 'end'>('start');
   readonly redirectionPath = input<
-    '/auth/forgot-password' | '/auth/register' | undefined
+    '/auth/forgot-password' | '/auth/signup' | undefined
   >(undefined);
   readonly redirectionLabel = input<'Forgot' | 'Register' | undefined>(
     undefined,


### PR DESCRIPTION
This pull request introduces the new `SignupPageComponent` for user registration and updates routing and UI references to support the new signup flow. The main changes include replacing the previous signup placeholder with the actual signup page, updating route links, and ensuring consistent naming across components.

**Signup page implementation:**

* Added the new `SignupPageComponent` and its template `signup-page.component.html`, featuring email/password fields, Google sign-in, and navigation to the login page. [[1]](diffhunk://#diff-6753177d1561c922aaabfb6bd95ae256f99c7dc7dad9e592fdde395fa3b1633cR1-R23) [[2]](diffhunk://#diff-2294d88f821bd71cc8b70d23f6008ae4c99017ad277e23927f1a4b46d4fd1787R1-R49)

**Routing and navigation updates:**

* Updated `auth.routes.ts` to use `SignupPageComponent` for the `/auth/signup` route instead of the placeholder `TemporalComponentComponent`. [[1]](diffhunk://#diff-3e52c1cc8d0453a506a51b6266dbd094cd99d9160db204a94769f330b317b21eR5) [[2]](diffhunk://#diff-3e52c1cc8d0453a506a51b6266dbd094cd99d9160db204a94769f330b317b21eL17-R18)
* Changed the login page link from `/auth/register` to `/auth/signup` for consistency and correct navigation.
* Updated the allowed values for `redirectionPath` in `InputComponent` to use `/auth/signup` instead of `/auth/register`.

**Component naming consistency:**

* Changed the selector for the login page component from `app-login-page` to `auth-login-page` to match the new signup page naming convention.

Closes #64 