### PR TITLE
feat(auth): add forgot password page and update routing

### DIFF
--- a/src/features/auth/auth.routes.ts
+++ b/src/features/auth/auth.routes.ts
@@ -3,6 +3,7 @@ import TemporalComponentComponent from '@features/notes/components/temporal-comp
 import { AuthLayoutComponent } from '@shared/layouts/auth-layout/auth-layout.component';
 import LoginPageComponent from './pages/login-page/login-page.component';
 import SignupPageComponent from './pages/signup-page/signup-page.component';
+import { ForgotPasswordPageComponent } from './pages/forgot-password-page/forgot-password-page.component';
 
 const authRoutes: Routes = [
   {
@@ -19,7 +20,7 @@ const authRoutes: Routes = [
       },
       {
         path: 'forgot-password',
-        loadComponent: () => TemporalComponentComponent,
+        loadComponent: () => ForgotPasswordPageComponent,
       },
       {
         path: 'reset-password',

--- a/src/features/auth/pages/forgot-password-page/forgot-password-page.component.html
+++ b/src/features/auth/pages/forgot-password-page/forgot-password-page.component.html
@@ -1,0 +1,25 @@
+<article class="w-full min-h-screen py-8 px-4 flex items-center justify-center">
+  <section
+    class="bg-white text-neutral-600 dark:bg-neutral-950 w-full md:w-[540px] px-6 py-8 flex flex-col gap-y-4 rounded-16 mx-auto md:p-12"
+  >
+    <header
+      class="flex flex-col justify-center items-center text-center gap-y-4"
+    >
+      <app-logo />
+      <div>
+        <app-title title="Forgotten your password?" />
+        <p class="text-preset-5 text-neutral-600 dark:text-neutral-300 mt-2">
+          Enter your email below, and we’ll send you a link to reset it.
+        </p>
+      </div>
+    </header>
+    <form class="flex flex-col gap-y-4 pt-6">
+      <app-input
+        name="email"
+        label="email address"
+        placeholder="email@example.com"
+      />
+      <app-button variant="primary" label="Send Reset Link" />
+    </form>
+  </section>
+</article>

--- a/src/features/auth/pages/forgot-password-page/forgot-password-page.component.ts
+++ b/src/features/auth/pages/forgot-password-page/forgot-password-page.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  SectionTitleComponent,
+  InputComponent,
+  ButtonComponent,
+  LogoComponent,
+} from '@shared/components';
+
+@Component({
+  selector: 'auth-forgot-password-page',
+  imports: [
+    SectionTitleComponent,
+    InputComponent,
+    ButtonComponent,
+    LogoComponent,
+  ],
+  templateUrl: './forgot-password-page.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ForgotPasswordPageComponent {}


### PR DESCRIPTION
This pull request introduces a new "Forgot Password" page to the authentication flow, replacing the previous placeholder component and integrating it with the routing and UI. The most important changes are grouped below:

**Routing Updates:**

* The `authRoutes` configuration in `src/features/auth/auth.routes.ts` is updated to use the new `ForgotPasswordPageComponent` for the `/forgot-password` route, replacing the previous placeholder (`TemporalComponentComponent`). [[1]](diffhunk://#diff-3e52c1cc8d0453a506a51b6266dbd094cd99d9160db204a94769f330b317b21eR6) [[2]](diffhunk://#diff-3e52c1cc8d0453a506a51b6266dbd094cd99d9160db204a94769f330b317b21eL22-R23)

**New Component Implementation:**

* Added `ForgotPasswordPageComponent` (`src/features/auth/pages/forgot-password-page/forgot-password-page.component.ts`) that imports shared UI components and sets up change detection.
* Created the corresponding HTML template (`src/features/auth/pages/forgot-password-page/forgot-password-page.component.html`) featuring a form for users to enter their email and request a password reset link, along with branding and instructions.