### PR TITLE
feat(auth): add reset password page and update routing

### DIFF
--- a/src/features/auth/auth.routes.ts
+++ b/src/features/auth/auth.routes.ts
@@ -1,9 +1,9 @@
 import { Routes } from '@angular/router';
-import TemporalComponentComponent from '@features/notes/components/temporal-component/temporal-component.component';
 import { AuthLayoutComponent } from '@shared/layouts/auth-layout/auth-layout.component';
 import LoginPageComponent from './pages/login-page/login-page.component';
 import SignupPageComponent from './pages/signup-page/signup-page.component';
-import { ForgotPasswordPageComponent } from './pages/forgot-password-page/forgot-password-page.component';
+import ForgotPasswordPageComponent from './pages/forgot-password-page/forgot-password-page.component';
+import ResetPasswordPageComponent from './pages/reset-password-page/reset-password-page.component';
 
 const authRoutes: Routes = [
   {
@@ -24,7 +24,7 @@ const authRoutes: Routes = [
       },
       {
         path: 'reset-password',
-        loadComponent: () => TemporalComponentComponent,
+        loadComponent: () => ResetPasswordPageComponent,
       },
     ],
   },

--- a/src/features/auth/pages/reset-password-page/reset-password-page.component.html
+++ b/src/features/auth/pages/reset-password-page/reset-password-page.component.html
@@ -1,0 +1,35 @@
+<article class="w-full min-h-screen py-8 px-4 flex items-center justify-center">
+  <section
+    class="bg-white text-neutral-600 dark:bg-neutral-950 w-full md:w-[540px] px-6 py-8 flex flex-col gap-y-4 rounded-16 mx-auto md:p-12"
+  >
+    <header
+      class="flex flex-col justify-center items-center text-center gap-y-4"
+    >
+      <app-logo />
+      <div>
+        <app-title title="Reset Your Password" />
+        <p class="text-preset-5 text-neutral-600 dark:text-neutral-300 mt-2">
+          Choose a new password to secure your account.
+        </p>
+      </div>
+    </header>
+    <form class="flex flex-col gap-y-4 pt-6">
+      <app-input
+        name="newPassword"
+        label="New Password"
+        iconName="show"
+        iconPlacement="end"
+        hintMessage="At least 8 characters"
+        type="password"
+      />
+      <app-input
+        name="confirmPassword"
+        label="Confirm New Password"
+        iconName="show"
+        iconPlacement="end"
+        type="password"
+      />
+      <app-button variant="primary" label="Reset Password" />
+    </form>
+  </section>
+</article>

--- a/src/features/auth/pages/reset-password-page/reset-password-page.component.ts
+++ b/src/features/auth/pages/reset-password-page/reset-password-page.component.ts
@@ -1,20 +1,20 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import {
   SectionTitleComponent,
+  LogoComponent,
   InputComponent,
   ButtonComponent,
-  LogoComponent,
 } from '@shared/components';
 
 @Component({
-  selector: 'auth-forgot-password-page',
+  selector: 'auth-reset-password-page',
   imports: [
     SectionTitleComponent,
+    LogoComponent,
     InputComponent,
     ButtonComponent,
-    LogoComponent,
   ],
-  templateUrl: './forgot-password-page.component.html',
+  templateUrl: './reset-password-page.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export default class ForgotPasswordPageComponent {}
+export default class ResetPasswordPageComponent {}


### PR DESCRIPTION
This pull request adds a new "Reset Password" page to the authentication flow and refactors related components for consistency and best practices. The main changes include creating the `ResetPasswordPageComponent`, updating routing to use this new component, and switching to default exports for page components.

**Authentication Flow Updates:**

* Added the new `ResetPasswordPageComponent` and its template, providing users with a form to reset their password. (`src/features/auth/pages/reset-password-page/reset-password-page.component.ts`, `src/features/auth/pages/reset-password-page/reset-password-page.component.html`) [[1]](diffhunk://#diff-3ea6be21d3d3a5b4907c5235d608a3b69ad50aff64c89ef9b22aa8ef4f2322dbR1-R20) [[2]](diffhunk://#diff-4a35e48d80449a093045a42569a767f0e276a414e60bf5343a46fa61f8a02282R1-R35)
* Updated routing in `auth.routes.ts` to load the new `ResetPasswordPageComponent` for the `reset-password` path instead of the placeholder `TemporalComponentComponent`. (`src/features/auth/auth.routes.ts`)

**Component Refactoring:**

* Changed the export of `ForgotPasswordPageComponent` to use a default export for consistency with other page components. (`src/features/auth/pages/forgot-password-page/forgot-password-page.component.ts`)
* Updated imports in `auth.routes.ts` to use default imports for password-related page components. (`src/features/auth/auth.routes.ts`)